### PR TITLE
Ocean Layer Not Rendering at Low Zoom Levels in PMTiles (GeoServer)

### DIFF
--- a/config.json
+++ b/config.json
@@ -145,7 +145,7 @@
             "simplify_ratio": 2
         },
         "ocean": {
-            "minzoom": 8,
+            "minzoom": 0,
             "maxzoom": 14,
             "source": "data/water-polygons-split-4326/water_polygons.shp",
             "source_columns": true,


### PR DESCRIPTION
<h3>Problem</h3><p>When serving <strong>PMTiles generated by shortbread-tilemaker</strong> through <strong>GeoServer using the PMTiles extension</strong> and <strong>MBStyle</strong>, ocean polygons do <strong>not render at zoom levels 0–7</strong>.</p><p>This happens because GeoServer relies on <strong>PMTiles layer metadata</strong> to decide which layers are available at a given zoom level.</p><hr><h3>Root Cause</h3><p>In <code inline="">config.json</code>:</p><ul><li><p>The <strong><code inline="">ocean</code></strong> layer is defined with:</p><pre><code class="language-json">"minzoom": 8
</code></pre></li><li><p>The <strong><code inline="">ocean-low</code></strong> layer covers zooms 0–7 and writes into <code inline="">ocean</code>:</p><pre><code class="language-json">"minzoom": 0,
"maxzoom": 7,
"write_to": "ocean"
</code></pre></li></ul><p>While tilemaker correctly merges <code inline="">ocean-low</code> geometries into the <code inline="">ocean</code> layer at zooms 0–7, <strong>PMTiles metadata only reflects the primary layer definition</strong>, resulting in:</p><pre><code class="language-json">"ocean": { "minzoom": 8, "maxzoom": 14 }
</code></pre><p>GeoServer (via the PMTiles extension) therefore assumes the <code inline="">ocean</code> layer does not exist below zoom 8 and does not render it, even though the tile data contains valid ocean polygons.</p><hr><h3>Solution</h3><p>Update the <code inline="">ocean</code> layer definition to match the <strong>actual data range after merging</strong>:</p><pre><code class="language-diff">"ocean": {
-  "minzoom": 8,
+  "minzoom": 0,
   "maxzoom": 14,
   ...
}
</code></pre><p>This ensures PMTiles metadata correctly advertises ocean data at all zoom levels, allowing GeoServer + MBStyle to render it correctly.</p><hr><h3>Testing</h3><ul><li><p>Generated PMTiles for the <strong>Europe</strong> region</p></li><li><p>Verified metadata now reports:</p><pre><code>"ocean": { "minzoom": 0, "maxzoom": 14 }
</code></pre></li><li><p>Confirmed ocean renders correctly at low zoom levels in <strong>GeoServer using the PMTiles extension and MBStyle</strong></p></li></ul><hr><h3>Visual Comparison</h3>

| Before | After |
| --- | --- |
| <img width="420" alt="Before" src="https://github.com/user-attachments/assets/47876594-886f-405d-9f1f-3af02aedadd7" /> | <img width="420" alt="After" src="https://github.com/user-attachments/assets/3708240f-918a-4500-b3f3-b8f66706392b" /> |
